### PR TITLE
Default curve scale management.

### DIFF
--- a/icepaposc/settings.py
+++ b/icepaposc/settings.py
@@ -37,7 +37,7 @@ class Settings:
         # Settings held by the GUI side.
         self.default_x_axis_length_min = 5  # [Seconds]
         self.default_x_axis_length_max = 3600  # [Seconds]
-        self.default_x_axis_length = 30  # [Seconds]
+        self.default_x_axis_length = 90  # [Seconds]
 
     def announce_update(self):
         self.collector.tick_interval = self.sample_rate

--- a/icepaposc/window_main.py
+++ b/icepaposc/window_main.py
@@ -364,6 +364,12 @@ class WindowMain(QtGui.QMainWindow):
         self._add_signal(drv_addr, 'StatMoving', 3)
         self._add_signal(drv_addr, 'StatSettling', 3)
         self._add_signal(drv_addr, 'StatOutofwin', 3)
+        self._add_signal(drv_addr, 'StatWarning', 3)
+        self.view_boxes[0].enableAutoRange(axis=self.view_boxes[0].YAxis)
+        self.view_boxes[1].disableAutoRange(axis=self.view_boxes[1].YAxis)
+        self.view_boxes[1].setYRange(-30, 70, padding=0)
+        self.view_boxes[2].disableAutoRange(axis=self.view_boxes[2].YAxis)
+        self.view_boxes[2].setYRange(-1, 20, padding=0)
 
     def _signals_currents(self):
         """Display a specific set of curves."""
@@ -377,7 +383,6 @@ class WindowMain(QtGui.QMainWindow):
         self.view_boxes[1].disableAutoRange(axis=self.view_boxes[1].YAxis)
         self.view_boxes[1].setYRange(-9, 10, padding=0)
         self.view_boxes[2].enableAutoRange(axis=self.view_boxes[2].YAxis)
-
 
     def _signals_target(self):
         """Display a specific set of curves."""

--- a/icepaposc/window_main.py
+++ b/icepaposc/window_main.py
@@ -372,6 +372,12 @@ class WindowMain(QtGui.QMainWindow):
         self._add_signal(drv_addr, 'PosAxis', 1)
         self._add_signal(drv_addr, 'MeasI', 2)
         self._add_signal(drv_addr, 'MeasVm', 3)
+        # Ajust plot axis
+        self.view_boxes[0].enableAutoRange(axis=self.view_boxes[0].YAxis)
+        self.view_boxes[1].disableAutoRange(axis=self.view_boxes[1].YAxis)
+        self.view_boxes[1].setYRange(-9, 10, padding=0)
+        self.view_boxes[2].enableAutoRange(axis=self.view_boxes[2].YAxis)
+
 
     def _signals_target(self):
         """Display a specific set of curves."""


### PR DESCRIPTION
Default curve scale management.

Current and close loop default curve agreement are overlapping. Manage the default Y range of the 3 plots axis can avoid that.


Also change default x axis length. From experience, 30 second is to small.