### PR TITLE
Add LICENSE to python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.md
+include LICENSE


### PR DESCRIPTION
The LICENSE is missing from the python package.
Adding it to the MANIFEST.in file ensures it will be included.
Added all .md files as well.