### PR TITLE
Fix QStyleOptionButton and QStyle import

### DIFF
--- a/icepaposc/custom_widgets/square_radiobtn.py
+++ b/icepaposc/custom_widgets/square_radiobtn.py
@@ -23,7 +23,7 @@ class Square_RadioBtn(QtWidgets.QRadioButton):
         # create a new painter on the widget
         qp = QtGui.QPainter(self)
         # create a styleoption and init it with the button
-        opt = QtGui.QStyleOptionButton()
+        opt = QtWidgets.QStyleOptionButton()
         self.initStyleOption(opt)
 
         # if there is an icon, draw it, otherwise draw a filled rect
@@ -44,7 +44,7 @@ class Square_RadioBtn(QtWidgets.QRadioButton):
         qp.setPen(blackpen)
 
         # if selected, draw a frame around it
-        if opt.state & (QtGui.QStyle.State_MouseOver | QtGui.QStyle.State_On):
+        if opt.state & (QtWidgets.QStyle.State_MouseOver | QtWidgets.QStyle.State_On):
             # ON state
             qp.drawRect(self.rect())
             # print("ON")


### PR DESCRIPTION
QStyleOptionButton and QStyle should be imported from the QtWidgets module.
In pyqt 5.6.0, they could be imported from both QtGui and QtWidgets but in 5.12.3, they aren't in QtGui anymore.

Fix #22

pyqt 5.6.0 is the oldest PyQt5 available on conda-forge, so I haven't tested with older versions.
If you think there is a risk that those classes need to be imported from `QtGui` on other versions, we could use a `try... except ImportError` but I think we should have a version where we can show the problem.

Which version of PyQt5 are you using?